### PR TITLE
session context for execute

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/visier/__init__.py
+++ b/visier/__init__.py
@@ -15,4 +15,4 @@
 Visier Public Python Connector
 """
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/visier/connector/__init__.py
+++ b/visier/connector/__init__.py
@@ -16,4 +16,4 @@ Visier Public Python Connector
 """
 
 from .authentication import Authentication
-from .sessions import VisierSession, ResultTable, QueryExecutionError
+from .sessions import VisierSession, ResultTable, SessionContext, QueryExecutionError


### PR DESCRIPTION
Enable more general execution of Visier APIs through the `VisierSession.execute` method.