### PR TITLE
Add User-Agent for usage tracking

### DIFF
--- a/visier/connector/constants.py
+++ b/visier/connector/constants.py
@@ -17,6 +17,8 @@ Visier Public Python Connector Constants
 """
 
 TARGET_TENANT_ID="TargetTenantID"
+USER_AGENT="User-Agent"
+USER_AGENT_VALUE="visier-python-connector"
 
 ENV_VISIER_USERNAME="VISIER_USERNAME"
 ENV_VISIER_PASSWORD="VISIER_PASSWORD"

--- a/visier/connector/sessions.py
+++ b/visier/connector/sessions.py
@@ -28,7 +28,7 @@ from requests import Session, Response
 from deprecated import deprecated
 from .table import ResultTable
 from .authentication import Authentication, OAuth2, Basic
-from .constants import TARGET_TENANT_ID
+from .constants import TARGET_TENANT_ID, USER_AGENT, USER_AGENT_VALUE
 from .callback import CallbackServer, CallbackBinding
 
 
@@ -71,6 +71,8 @@ class SessionContext:
         self._session = session
         self._host = host
         self._target_tenant_id = target_tenant_id
+        # Set the User-Agent header for internal tracking purposes
+        self._session.headers.update({USER_AGENT: USER_AGENT_VALUE})
 
     def session(self) -> Session:
         """Returns the current session object"""
@@ -212,7 +214,7 @@ class VisierSession:
             body["redirect_uri"] = auth.redirect_uri
         response = requests.post(url=url,
                                  data=body,
-                                 headers={"apikey": auth.api_key},
+                                 headers={"apikey": auth.api_key, USER_AGENT: USER_AGENT_VALUE},
                                  timeout=self._timeout,
                                  auth=get_client_auth())
         response.raise_for_status()


### PR DESCRIPTION
Adding the `User-Agent` header to be able to distinguish requests that are made from the Python Connector.

Sample logged strings:

`REQUEST-AUTHENTICATED (48 ms): GET /hr/api/model/analytic-objects ...[Details omitted]... UserAgent=visier-python-connector`

`REQUEST-START: POST /hr/api/query/list ...[Details omitted]... UserAgent=visier-python-connector`
