### PR TITLE
Add connector for DV Export API

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ with VisierSession(auth) as s:
     print(f"Retrieved export metadata: {export_metadata_response.json()}")
 ```
 
-### Download a File From A Data Version Export
+### Download a File From a Data Version Export
 After the DV export job completes, you can use the returned export ID to retrieve information about the tables 
 in the data version and data files for the tables. Then, use the file ID to download a specific table from the data version export. The file contains DV records for
 a particular table's columns; for example, the columns in the Employee table.

--- a/README.md
+++ b/README.md
@@ -344,16 +344,16 @@ with VisierSession(auth) as s:
 ```
 
 ## Data Version Export API
-Data Version (DV) Export API allows users to export DV data in a CSV format.
+The Data Version (DV) Export API allows users to export data version information, such as tables, columns, and file information, in CSV format.
 
 To use the connector, add the following statement to your program.
 ```python
 from visier.api import DVExportApiClient
 ```
 
-### Schedule a DV export job
-Use the client to schedule a DV export job, poll its status until completion to retrieve the export ID, then get the 
-export metadata.
+### Schedule a Data Version Export Job
+Use the client to schedule a DV export job, poll the job's status until completion to retrieve the export ID, then get the 
+export information.
 ```python
 with VisierSession(auth) as s:
     dv_export_client = DVExportApiClient(s)
@@ -384,10 +384,11 @@ with VisierSession(auth) as s:
     print(f"Retrieved export metadata: {export_metadata_response.json()}")
 ```
 
-### Get data file from export
-Once you have completed a DV export job, you should use the returned export ID to retrieve metadata about the different tables 
-in the data version as well as files for those tables.
-#### Decompress file during download
+### Download a File From A Data Version Export
+After the DV export job completes, you can use the returned export ID to retrieve information about the tables 
+in the data version and data files for the tables. Then, use the file ID to download a specific table from the data version export. The file contains DV records for
+a particular table's columns; for example, the columns in the Employee table.
+#### Decompress File During Download
 ```python
     with dv_export_client.get_export_file(export_id, file_id) as r:
         with open(full_file_path, 'wb') as f:
@@ -396,8 +397,8 @@ in the data version as well as files for those tables.
                     f.write(chunk)
 ```
 
-#### Download as compressed file
-Set `stream=True` if you would like to avoid decompressing the file on download. 
+#### Download as Compressed File (Optional)
+To avoid decompressing the file during download, set `stream=True`. 
 ```python
     with dv_export_client.get_export_file(export_id, file_id, stream=True) as r:
         with open(full_file_path, 'wb') as f:
@@ -406,22 +407,22 @@ Set `stream=True` if you would like to avoid decompressing the file on download.
                     f.write(chunk)
 ```
 
-### Get data versions available for export
-Use this method to see which data versions you can run an export job on.
+### Retrieve a List of All Data Versions
+Use this method to get the available data versions that you can export.
 ```python
     dv_response = dv_export_client.get_data_versions_available_for_export()
     print(f"Retrieved available data versions:  {dv_response.json()}")
 ```
 
-### Get completed exports
-Use this method to see the export metadata from DV export jobs which have already completed.
+### Retrieve the Details of All Data Version Exports
+Use this method to get the export information for all completed export jobs.
 ```python
     exports_response = dv_export_client.get_available_data_version_exports()
     print(f"Full metadata for all DV exports retrieved: {exports_response.json()}")
 ```
 
-### More examples
-For a more complex script example which shows how the DV Export API client can be used to export a DV into a database, see 
+### More Examples
+For a script example that shows how the Data Version Export API client can export a data version into a database, see 
 [github.com/visier/api-samples](https://github.com/visier/api-samples).
 
 ## Installation

--- a/visier/__init__.py
+++ b/visier/__init__.py
@@ -16,4 +16,4 @@
 Visier Public Python Connector
 """
 
-__version__ = "0.9.17"
+__version__ = "0.9.18"

--- a/visier/api/__init__.py
+++ b/visier/api/__init__.py
@@ -20,3 +20,4 @@ from .model import ModelApiClient
 from .query import QueryApiClient
 from .direct_intake import DirectIntakeApiClient
 from .intake import DataIntakeApiClient
+from .dv_export import DVExportApiClient

--- a/visier/api/dv_export.py
+++ b/visier/api/dv_export.py
@@ -61,7 +61,7 @@ class DVExportApiClient(ApiClientBase):
 
     def get_data_versions_available_for_export(self) -> Response:
         def call_impl(context: SessionContext) -> Response:
-            url = context.mk_url(f"{BASE_PATH}/availableDataVersions")
+            url = context.mk_url(f"{BASE_PATH}/data-versions")
             return context.session().get(url, headers=context.mk_headers())
 
         return self.run(call_impl)

--- a/visier/api/dv_export.py
+++ b/visier/api/dv_export.py
@@ -27,10 +27,10 @@ class DVExportApiClient(ApiClientBase):
 
     def schedule_initial_data_version_export_job(self, data_version_number: int) -> Response:
         """
-        Schedule an initial data version export job. An initial data version export job should be run if you are
-        trying to create an initial data store for the data version export, as the metadata retrieved via
-        `get_dava_version_export_metadata` will contain all the required information to create new tables.
-        :param data_version_number: The DV number you want to export
+        Schedule an initial data version export job. You might want to run an initial data version export job if you are
+        creating an initial data store for the data version export. The information returned through
+        `get_data_version_export_metadata` contains all the required details to create new tables.
+        :param data_version_number: The DV number you want to export.
         """
         def call_impl(context: SessionContext) -> Response:
             url = context.mk_url(f"{BASE_PATH}/jobs")
@@ -44,11 +44,11 @@ class DVExportApiClient(ApiClientBase):
                                                data_version_number: int,
                                                base_data_version_number: int) -> Response:
         """
-        Schedule a delta data version export job. A delta data version export job should be run if have already
-        exported an initial data version and want to export the changes in data between ``data_version_number``
+        Schedule a delta data version export job. Run a delta data version export job if you already
+        exported an initial data version and want to export the changes between ``data_version_number``
         and ``base_data_version_number``.
-        :param data_version_number: Data version number to export
-        :param base_data_version_number: Data version number to compute diff from
+        :param data_version_number: The data version number to export.
+        :param base_data_version_number: The data version number to compare against.
         """
         def call_impl(context: SessionContext) -> Response:
             url = context.mk_url(f"{BASE_PATH}/jobs")
@@ -63,7 +63,7 @@ class DVExportApiClient(ApiClientBase):
 
     def get_data_version_export_job_status(self, job_id: str) -> Response:
         """
-        Check the status of a DV export job. ``job_id`` can be retrieved from the response returned by
+        Check the status of a data version export job. Retrieve ``job_id`` from the response returned by
         ``schedule_initial_data_version_export_job`` or  ``schedule_delta_data_version_export_job``.
         :param job_id: The job ID of a scheduled DV export job.
         """
@@ -74,7 +74,7 @@ class DVExportApiClient(ApiClientBase):
 
     def get_data_version_export_metadata(self, export_id: str):
         """
-        After the DV export job has completed, get the DV export metadata. The ``export_id`` can be retrieved
+        After the DV export job completes, get the DV export details. Retrieve ``export_id``
         from the response returned by ``get_data_version_export_job_status``.
         :param export_id: The export ID of the completed DV export job.
         """
@@ -85,7 +85,7 @@ class DVExportApiClient(ApiClientBase):
 
     def get_data_versions_available_for_export(self) -> Response:
         """
-        Returns a list of metadata for all data versions which are available to run an export job on.
+        Returns details for all data versions on which you can run a DV export job.
         """
         def call_impl(context: SessionContext) -> Response:
             url = context.mk_url(f"{BASE_PATH}/data-versions")
@@ -94,8 +94,7 @@ class DVExportApiClient(ApiClientBase):
 
     def get_available_data_version_exports(self) -> Response:
         """
-        Returns a list of export metadata for all data version export jobs that have successfully run for this tenant
-        that haven't expired.
+        Returns a list of all available data version exports. Data version exports are available for 14 days after export job completes.
         """
         def call_impl(context: SessionContext) -> Response:
             url = context.mk_url(f"{BASE_PATH}/exports")
@@ -104,13 +103,13 @@ class DVExportApiClient(ApiClientBase):
 
     def get_export_file(self, export_id: str, file_id: str, stream=False) -> Response:
         """
-        Get a single file with ID ``file_id`` for specific data version export with ID ``export_id``. The file is
-        gz compressed on the server. Leaving ``stream=False`` will let you automatically decode the file as it is
-        downloaded. Set ``stream=True`` if you would like to download the compressed file as raw bytes and decode it later.
-        :param export_id: The ID of the export job the file is a part of
-        :param file_id: The ID of the file within the ``export_id`` to download
-        :param stream: Boolean to pass to underlying ``Requests`` call. Set to ``True`` if you want to access raw bytes.
-            The default value is ``False``.
+        Download a file with ID ``file_id`` for specific data version export with ID ``export_id``. The file is
+        gz compressed on the server. The default ``stream=False`` lets you automatically decode the file during
+        download. Set ``stream=True`` to download the compressed file as raw bytes to decode later.
+        :param export_id: The ID of the export job that contains the file.
+        :param file_id: The ID of the file within the ``export_id`` to download.
+        :param stream: Boolean to pass to underlying ``Requests`` call. If ``True``, gives access raw bytes.
+            The default is ``False``.
         """
         def call_impl(context: SessionContext) -> Response:
             url = context.mk_url(f"{BASE_PATH}/exports/{export_id}/files/{file_id}")

--- a/visier/api/dv_export.py
+++ b/visier/api/dv_export.py
@@ -23,7 +23,7 @@ import json
 BASE_PATH = "/v1alpha/data/data-version-exports"
 
 class DVExportApiClient(ApiClientBase):
-    """API client for the Visier DV Export API."""
+    """API client for the Visier Data Version Export API."""
 
     def schedule_initial_data_version_export_job(self, data_version_number: int) -> Response:
         def call_impl(context: SessionContext) -> Response:
@@ -39,7 +39,10 @@ class DVExportApiClient(ApiClientBase):
                                                base_data_version_number: int) -> Response:
         def call_impl(context: SessionContext) -> Response:
             url = context.mk_url(f"{BASE_PATH}/jobs")
-            payload = {'dataVersionNumber': str(data_version_number), 'baseDataVersionNumber': str(base_data_version_number)}
+            payload = {
+                'dataVersionNumber': str(data_version_number),
+                'baseDataVersionNumber': str(base_data_version_number)
+            }
             headers = context.mk_headers()
             headers['Content-Type'] = "application/json"
             return context.session().post(url, headers=headers, data=json.dumps(payload))

--- a/visier/api/dv_export.py
+++ b/visier/api/dv_export.py
@@ -15,10 +15,10 @@
 """
 API client for the Visier DV Export API.
 """
+import json
 from requests import Response
 from visier.api.base import ApiClientBase
 from visier.connector import SessionContext
-import json
 
 BASE_PATH = "/v1alpha/data/data-version-exports"
 

--- a/visier/api/dv_export.py
+++ b/visier/api/dv_export.py
@@ -28,7 +28,7 @@ class DVExportApiClient(ApiClientBase):
     def schedule_initial_data_version_export_job(self, data_version_number: int) -> Response:
         """
         Schedule an initial data version export job. An initial data version export job should be run if you are
-        trying to create an initial data store for the data version export, as the metadata, retrieved via
+        trying to create an initial data store for the data version export, as the metadata retrieved via
         `get_dava_version_export_metadata` will contain all the required information to create new tables.
         :param data_version_number: The DV number you want to export
         """
@@ -85,7 +85,7 @@ class DVExportApiClient(ApiClientBase):
 
     def get_data_versions_available_for_export(self) -> Response:
         """
-        Returns a list of all data version numbers which are available to run an export job on.
+        Returns a list of metadata for all data versions which are available to run an export job on.
         """
         def call_impl(context: SessionContext) -> Response:
             url = context.mk_url(f"{BASE_PATH}/data-versions")
@@ -105,8 +105,8 @@ class DVExportApiClient(ApiClientBase):
     def get_export_file(self, export_id: str, file_id: str, stream=False) -> Response:
         """
         Get a single file with ID ``file_id`` for specific data version export with ID ``export_id``. The file is
-        gz compressed on the server. Leaving ``stream=False`` will automatically decode the file as it is downloaded.
-        Set ``stream=True`` if you would like to download the compressed file as raw bytes and decode it later.
+        gz compressed on the server. Leaving ``stream=False`` will let you automatically decode the file as it is
+        downloaded. Set ``stream=True`` if you would like to download the compressed file as raw bytes and decode it later.
         :param export_id: The ID of the export job the file is a part of
         :param file_id: The ID of the file within the ``export_id`` to download
         :param stream: Boolean to pass to underlying ``Requests`` call. Set to ``True`` if you want to access raw bytes.

--- a/visier/api/dv_export.py
+++ b/visier/api/dv_export.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-API client for the Visier DV Export API.
+API client for the Visier Data Version Export API.
 """
 import json
 from requests import Response
@@ -26,6 +26,12 @@ class DVExportApiClient(ApiClientBase):
     """API client for the Visier Data Version Export API."""
 
     def schedule_initial_data_version_export_job(self, data_version_number: int) -> Response:
+        """
+        Schedule an initial data version export job. An initial data version export job should be run if you are
+        trying to create an initial data store for the data version export, as the metadata, retrieved via
+        `get_dava_version_export_metadata` will contain all the required information to create new tables.
+        :param data_version_number: The DV number you want to export
+        """
         def call_impl(context: SessionContext) -> Response:
             url = context.mk_url(f"{BASE_PATH}/jobs")
             payload = {'dataVersionNumber': str(data_version_number)}
@@ -37,6 +43,13 @@ class DVExportApiClient(ApiClientBase):
     def schedule_delta_data_version_export_job(self,
                                                data_version_number: int,
                                                base_data_version_number: int) -> Response:
+        """
+        Schedule a delta data version export job. A delta data version export job should be run if have already
+        exported an initial data version and want to export the changes in data between ``data_version_number``
+        and ``base_data_version_number``.
+        :param data_version_number: Data version number to export
+        :param base_data_version_number: Data version number to compute diff from
+        """
         def call_impl(context: SessionContext) -> Response:
             url = context.mk_url(f"{BASE_PATH}/jobs")
             payload = {
@@ -49,33 +62,56 @@ class DVExportApiClient(ApiClientBase):
         return self.run(call_impl)
 
     def get_data_version_export_job_status(self, job_id: str) -> Response:
+        """
+        Check the status of a DV export job. ``job_id`` can be retrieved from the response returned by
+        ``schedule_initial_data_version_export_job`` or  ``schedule_delta_data_version_export_job``.
+        :param job_id: The job ID of a scheduled DV export job.
+        """
         def call_impl(context: SessionContext) -> Response:
             url = context.mk_url(f"{BASE_PATH}/jobs/{job_id}")
             return context.session().get(url, headers=context.mk_headers())
-
         return self.run(call_impl)
 
-    def get_dava_version_export_metadata(self, export_id: str):
+    def get_data_version_export_metadata(self, export_id: str):
+        """
+        After the DV export job has completed, get the DV export metadata. The ``export_id`` can be retrieved
+        from the response returned by ``get_data_version_export_job_status``.
+        :param export_id: The export ID of the completed DV export job.
+        """
         def call_impl(context: SessionContext) -> Response:
             url = context.mk_url(f"{BASE_PATH}/exports/{export_id}")
             return context.session().get(url, headers=context.mk_headers())
-
         return self.run(call_impl)
 
     def get_data_versions_available_for_export(self) -> Response:
+        """
+        Returns a list of all data version numbers which are available to run an export job on.
+        """
         def call_impl(context: SessionContext) -> Response:
             url = context.mk_url(f"{BASE_PATH}/data-versions")
             return context.session().get(url, headers=context.mk_headers())
-
         return self.run(call_impl)
 
     def get_available_data_version_exports(self) -> Response:
+        """
+        Returns a list of export metadata for all data version export jobs that have successfully run for this tenant
+        that haven't expired.
+        """
         def call_impl(context: SessionContext) -> Response:
             url = context.mk_url(f"{BASE_PATH}/exports")
             return context.session().get(url, headers=context.mk_headers())
         return self.run(call_impl)
 
     def get_export_file(self, export_id: str, file_id: str, stream=False) -> Response:
+        """
+        Get a single file with ID ``file_id`` for specific data version export with ID ``export_id``. The file is
+        gz compressed on the server. Leaving ``stream=False`` will automatically decode the file as it is downloaded.
+        Set ``stream=True`` if you would to download the compressed file as raw bytes and decode it later.
+        :param export_id: The ID of the export job the file is a part of
+        :param file_id: The ID of the file within the ``export_id`` to download
+        :param stream: Boolean to pass to underlying ``Requests`` call. Set to ``True`` if you want to access raw bytes.
+            The default value is ``False``.
+        """
         def call_impl(context: SessionContext) -> Response:
             url = context.mk_url(f"{BASE_PATH}/exports/{export_id}/files/{file_id}")
             return context.session().get(url, headers=context.mk_headers(), stream=stream)

--- a/visier/api/dv_export.py
+++ b/visier/api/dv_export.py
@@ -1,0 +1,79 @@
+# Copyright 2023 Visier Solutions Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+API client for the Visier DV Export API.
+"""
+from requests import Response
+from visier.api.base import ApiClientBase
+from visier.connector import SessionContext
+import json
+
+BASE_PATH = "/v1alpha/data/data-version-exports"
+
+class DVExportApiClient(ApiClientBase):
+    """API client for the Visier DV Export API."""
+
+    def schedule_initial_data_version_export_job(self, data_version_number: int) -> Response:
+        def call_impl(context: SessionContext) -> Response:
+            url = context.mk_url(f"{BASE_PATH}/jobs")
+            payload = {'dataVersionNumber': str(data_version_number)}
+            headers = context.mk_headers()
+            headers['Content-Type'] = "application/json"
+            return context.session().post(url, headers=headers, data=json.dumps(payload))
+        return self.run(call_impl)
+
+    def schedule_delta_data_version_export_job(self,
+                                               data_version_number: int,
+                                               base_data_version_number: int) -> Response:
+        def call_impl(context: SessionContext) -> Response:
+            url = context.mk_url(f"{BASE_PATH}/jobs")
+            payload = {'dataVersionNumber': str(data_version_number), 'baseDataVersionNumber': str(base_data_version_number)}
+            headers = context.mk_headers()
+            headers['Content-Type'] = "application/json"
+            return context.session().post(url, headers=headers, data=json.dumps(payload))
+        return self.run(call_impl)
+
+    def get_data_version_export_job_status(self, job_id: str) -> Response:
+        def call_impl(context: SessionContext) -> Response:
+            url = context.mk_url(f"{BASE_PATH}/jobs/{job_id}")
+            return context.session().get(url, headers=context.mk_headers())
+
+        return self.run(call_impl)
+
+    def get_dava_version_export_metadata(self, export_id: str):
+        def call_impl(context: SessionContext) -> Response:
+            url = context.mk_url(f"{BASE_PATH}/exports/{export_id}")
+            return context.session().get(url, headers=context.mk_headers())
+
+        return self.run(call_impl)
+
+    def get_data_versions_available_for_export(self) -> Response:
+        def call_impl(context: SessionContext) -> Response:
+            url = context.mk_url(f"{BASE_PATH}/availableDataVersions")
+            return context.session().get(url, headers=context.mk_headers())
+
+        return self.run(call_impl)
+
+    def get_available_data_version_exports(self) -> Response:
+        def call_impl(context: SessionContext) -> Response:
+            url = context.mk_url(f"{BASE_PATH}/exports")
+            return context.session().get(url, headers=context.mk_headers())
+        return self.run(call_impl)
+
+    def get_export_file(self, export_id: str, file_id: str) -> Response:
+        def call_impl(context: SessionContext) -> Response:
+            url = context.mk_url(f"{BASE_PATH}/exports/{export_id}/files/{file_id}")
+            return context.session().get(url, headers=context.mk_headers())
+        return self.run(call_impl)

--- a/visier/api/dv_export.py
+++ b/visier/api/dv_export.py
@@ -106,7 +106,7 @@ class DVExportApiClient(ApiClientBase):
         """
         Get a single file with ID ``file_id`` for specific data version export with ID ``export_id``. The file is
         gz compressed on the server. Leaving ``stream=False`` will automatically decode the file as it is downloaded.
-        Set ``stream=True`` if you would to download the compressed file as raw bytes and decode it later.
+        Set ``stream=True`` if you would like to download the compressed file as raw bytes and decode it later.
         :param export_id: The ID of the export job the file is a part of
         :param file_id: The ID of the file within the ``export_id`` to download
         :param stream: Boolean to pass to underlying ``Requests`` call. Set to ``True`` if you want to access raw bytes.

--- a/visier/api/dv_export.py
+++ b/visier/api/dv_export.py
@@ -108,7 +108,7 @@ class DVExportApiClient(ApiClientBase):
         download. Set ``stream=True`` to download the compressed file as raw bytes to decode later.
         :param export_id: The ID of the export job that contains the file.
         :param file_id: The ID of the file within the ``export_id`` to download.
-        :param stream: Boolean to pass to underlying ``Requests`` call. If ``True``, gives access raw bytes.
+        :param stream: Boolean to pass to underlying ``Requests`` call. If ``True``, gives access to raw bytes.
             The default is ``False``.
         """
         def call_impl(context: SessionContext) -> Response:

--- a/visier/api/dv_export.py
+++ b/visier/api/dv_export.py
@@ -75,8 +75,8 @@ class DVExportApiClient(ApiClientBase):
             return context.session().get(url, headers=context.mk_headers())
         return self.run(call_impl)
 
-    def get_export_file(self, export_id: str, file_id: str) -> Response:
+    def get_export_file(self, export_id: str, file_id: str, stream=False) -> Response:
         def call_impl(context: SessionContext) -> Response:
             url = context.mk_url(f"{BASE_PATH}/exports/{export_id}/files/{file_id}")
-            return context.session().get(url, headers=context.mk_headers())
+            return context.session().get(url, headers=context.mk_headers(), stream=stream)
         return self.run(call_impl)


### PR DESCRIPTION
This PR adds a new connector for the Data Version Export API. The connector can make calls to all 6 public endpoints:

GET /v1alpha/data/data-version-exports/data-versions (`get_data_versions_available_for_export`)

GET /v1alpha/data/data-version-exports/exports (`get_available_data_version_exports`)

GET /v1alpha/data/data-version-exports/exports/{exportUuid} (`get_data_version_export_metadata`)

POST /v1alpha/data/data-version-exports/jobs (`schedule_initial_data_version_export_job` and `schedule_delta_data_version_export_job`)

GET /v1alpha/data/data-version-exports/jobs/{jobUuid} (`get_data_version_export_job_status`)

GET /v1alpha/data/data-version-exports/exports/{exportUuid}/files/{fileId} (`get_export_file`)

This connector is going to be used by the API sample in this PR: https://github.com/visier/api-samples/pull/7