### PR TITLE
fix linter for positional args

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,6 @@
 [MASTER]
 max-args = 9
 max-attributes = 9
+max-positional-arguments = 9
 max-line-length = 140
 disable = R0801


### PR DESCRIPTION
Add linter config to allow 9 pos args