### PR TITLE
Update sql-like query to use aggregateQueryOptions over options

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ with VisierSession(auth) as s:
 ```
 
 #### SQL-Like Aggregate Query
-In this example, we define a snippet to aggregate `employeeCount` by `Location_0`, `Gender`, `Union_Status`, and `Location_1` for 4 periods of 3 months each starting from April 1, 2020. In aggregate SQL-like queries, you can use `options` to eliminate cells with zero and null values. This reduces the size of the overall result set to only include rows whose metric value is more than 0.
+In this example, we define a snippet to aggregate `employeeCount` by `Location_0`, `Gender`, `Union_Status`, and `Location_1` for 4 periods of 3 months each starting from April 1, 2020. In aggregate SQL-like queries, you can use `aggregateQueryOptions` to eliminate cells with zero and null values. This reduces the size of the overall result set to only include rows whose metric value is more than 0.
 ```python
 with VisierSession(auth) as s:
     client = QueryApiClient(s)

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ with VisierSession(auth) as s:
 You can write SQL-like queries to define both list and aggregate queries.
 
 #### SQL-Like List Query
-In this example, we define a snippet to get the `EmployeeID`, `Union_Status`, `Direct_Manager.Gender`, `Direct_Manager.Vaccination_Status` where `isFemale` = `TRUE` and `isHighPerformer` = `TRUE` between January 1, 2020 and December 31, 2021. In list SQL-like queries, you can use `list_query_options`, see [Visier documentation](https://docs.visier.com/developer/apis/references/api-reference.htm#tag/DataQuery/operation/DataQuery_SqlLike) for all available list options.
+In this example, we define a snippet to get the `EmployeeID`, `Union_Status`, `Direct_Manager.Gender`, `Direct_Manager.Vaccination_Status` where `isFemale` = `TRUE` and `isHighPerformer` = `TRUE` between January 1, 2020 and December 31, 2021. For more information about the available list options, see [Query aggregate or list data using SQL-like syntax](https://docs.visier.com/developer/apis/references/api-reference.htm#tag/DataQuery/operation/DataQuery_SqlLike).
 ```python
 with VisierSession(auth) as s:
     client = QueryApiClient(s)
@@ -261,7 +261,7 @@ with VisierSession(auth) as s:
 ```
 
 #### SQL-Like Aggregate Query
-In this example, we define a snippet to aggregate `employeeCount` by `Location_0`, `Gender`, `Union_Status`, and `Location_1` for 4 periods of 3 months each starting from April 1, 2020. In aggregate SQL-like queries, you can use `aggregate_query_options` to eliminate cells with zero and null values. This reduces the size of the overall result set to only include rows whose metric value is more than 0. See [Visier documentation](https://docs.visier.com/developer/apis/references/api-reference.htm#tag/DataQuery/operation/DataQuery_SqlLike) for all available aggregate options.
+In this example, we define a snippet to aggregate `employeeCount` by `Location_0`, `Gender`, `Union_Status`, and `Location_1` for 4 periods of 3 months each starting from April 1, 2020. In aggregate SQL-like queries, you can use `aggregate_query_options` to eliminate cells with zero and null values. This reduces the size of the overall result set to only include rows whose metric value is more than 0. For more information about the available aggregate options, see [Query aggregate or list data using SQL-like syntax](https://docs.visier.com/developer/apis/references/api-reference.htm#tag/DataQuery/operation/DataQuery_SqlLike).
 ```python
 with VisierSession(auth) as s:
     client = QueryApiClient(s)

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ with VisierSession(auth) as s:
 You can write SQL-like queries to define both list and aggregate queries.
 
 #### SQL-Like List Query
-In this example, we define a snippet to get the `EmployeeID`, `Union_Status`, `Direct_Manager.Gender`, `Direct_Manager.Vaccination_Status` where `isFemale` = `TRUE` and `isHighPerformer` = `TRUE` between January 1, 2020 and December 31, 2021.
+In this example, we define a snippet to get the `EmployeeID`, `Union_Status`, `Direct_Manager.Gender`, `Direct_Manager.Vaccination_Status` where `isFemale` = `TRUE` and `isHighPerformer` = `TRUE` between January 1, 2020 and December 31, 2021. In list SQL-like queries, you can use `list_query_options`, see [Visier documentation](https://docs.visier.com/developer/apis/references/api-reference.htm#tag/DataQuery/operation/DataQuery_SqlLike) for all available list options.
 ```python
 with VisierSession(auth) as s:
     client = QueryApiClient(s)
@@ -261,7 +261,7 @@ with VisierSession(auth) as s:
 ```
 
 #### SQL-Like Aggregate Query
-In this example, we define a snippet to aggregate `employeeCount` by `Location_0`, `Gender`, `Union_Status`, and `Location_1` for 4 periods of 3 months each starting from April 1, 2020. In aggregate SQL-like queries, you can use `aggregateQueryOptions` to eliminate cells with zero and null values. This reduces the size of the overall result set to only include rows whose metric value is more than 0.
+In this example, we define a snippet to aggregate `employeeCount` by `Location_0`, `Gender`, `Union_Status`, and `Location_1` for 4 periods of 3 months each starting from April 1, 2020. In aggregate SQL-like queries, you can use `aggregate_query_options` to eliminate cells with zero and null values. This reduces the size of the overall result set to only include rows whose metric value is more than 0. See [Visier documentation](https://docs.visier.com/developer/apis/references/api-reference.htm#tag/DataQuery/operation/DataQuery_SqlLike) for all available aggregate options.
 ```python
 with VisierSession(auth) as s:
     client = QueryApiClient(s)

--- a/visier/__init__.py
+++ b/visier/__init__.py
@@ -16,4 +16,4 @@
 Visier Public Python Connector
 """
 
-__version__ = "0.9.18"
+__version__ = "0.9.19"

--- a/visier/api/query.py
+++ b/visier/api/query.py
@@ -36,11 +36,11 @@ class QueryApiClient(ApiClientBase):
         """Execute a Visier snapshot query and return a tabular result."""
         return self._execute_query_api("/v1/data/query/snapshot", query_def)
 
-    def sqllike(self, sql_query: str, aggregate_query_options = None):
+    def sqllike(self, sql_query: str, options = None):
         """Execute a Visier SQL-like query statement and return a tabular result."""
         body = {"query" : sql_query}
-        if aggregate_query_options:
-            body["aggregateQueryOptions"] = aggregate_query_options
+        if options:
+            body["aggregateQueryOptions"] = options
         return self._execute_query_api("/v1/data/query/sql", body)
 
     def _execute_query_api(self, path: str, body: object):

--- a/visier/api/query.py
+++ b/visier/api/query.py
@@ -36,11 +36,13 @@ class QueryApiClient(ApiClientBase):
         """Execute a Visier snapshot query and return a tabular result."""
         return self._execute_query_api("/v1/data/query/snapshot", query_def)
 
-    def sqllike(self, sql_query: str, options = None):
+    def sqllike(self, sql_query: str, aggregate_query_options = None, list_query_options = None):
         """Execute a Visier SQL-like query statement and return a tabular result."""
         body = {"query" : sql_query}
-        if options:
-            body["aggregateQueryOptions"] = options
+        if aggregate_query_options:
+            body["aggregateQueryOptions"] = aggregate_query_options
+        if list_query_options:
+            body["listQueryOptions"] = list_query_options
         return self._execute_query_api("/v1/data/query/sql", body)
 
     def _execute_query_api(self, path: str, body: object):

--- a/visier/api/query.py
+++ b/visier/api/query.py
@@ -36,11 +36,11 @@ class QueryApiClient(ApiClientBase):
         """Execute a Visier snapshot query and return a tabular result."""
         return self._execute_query_api("/v1/data/query/snapshot", query_def)
 
-    def sqllike(self, sql_query: str, options = None):
+    def sqllike(self, sql_query: str, aggregate_query_options = None):
         """Execute a Visier SQL-like query statement and return a tabular result."""
         body = {"query" : sql_query}
-        if options:
-            body["options"] = options
+        if aggregate_query_options:
+            body["aggregateQueryOptions"] = aggregate_query_options
         return self._execute_query_api("/v1/data/query/sql", body)
 
     def _execute_query_api(self, path: str, body: object):

--- a/visier/connector/sessions.py
+++ b/visier/connector/sessions.py
@@ -116,11 +116,13 @@ class VisierSession:
         return self._execute_query_api("/v1/data/query/list", query_def)
 
     @deprecated(version="0.9.5", reason="Use visier.api.QueryApiClient instead")
-    def execute_sqllike(self, sql_query: str, options = None):
+    def execute_sqllike(self, sql_query: str, aggregate_query_options = None, list_query_options = None):
         """Execute a Visier SQL-like query statement and return a tabular result."""
         body = {"query" : sql_query}
-        if options:
-            body["aggregateQueryOptions"] = options
+        if aggregate_query_options:
+            body["aggregateQueryOptions"] = aggregate_query_options
+        if list_query_options:
+            body["listQueryOptions"] = list_query_options
         return self._execute_query_api("/v1/data/query/sql", body)
 
     def execute(self, call_function: Callable[[SessionContext], Response]) -> Response:

--- a/visier/connector/sessions.py
+++ b/visier/connector/sessions.py
@@ -116,11 +116,11 @@ class VisierSession:
         return self._execute_query_api("/v1/data/query/list", query_def)
 
     @deprecated(version="0.9.5", reason="Use visier.api.QueryApiClient instead")
-    def execute_sqllike(self, sql_query: str, aggregate_query_options = None):
+    def execute_sqllike(self, sql_query: str, options = None):
         """Execute a Visier SQL-like query statement and return a tabular result."""
         body = {"query" : sql_query}
-        if aggregate_query_options:
-            body["aggregateQueryOptions"] = aggregate_query_options
+        if options:
+            body["aggregateQueryOptions"] = options
         return self._execute_query_api("/v1/data/query/sql", body)
 
     def execute(self, call_function: Callable[[SessionContext], Response]) -> Response:

--- a/visier/connector/sessions.py
+++ b/visier/connector/sessions.py
@@ -116,11 +116,11 @@ class VisierSession:
         return self._execute_query_api("/v1/data/query/list", query_def)
 
     @deprecated(version="0.9.5", reason="Use visier.api.QueryApiClient instead")
-    def execute_sqllike(self, sql_query: str, options = None):
+    def execute_sqllike(self, sql_query: str, aggregate_query_options = None):
         """Execute a Visier SQL-like query statement and return a tabular result."""
         body = {"query" : sql_query}
-        if options:
-            body["options"] = options
+        if aggregate_query_options:
+            body["aggregateQueryOptions"] = aggregate_query_options
         return self._execute_query_api("/v1/data/query/sql", body)
 
     def execute(self, call_function: Callable[[SessionContext], Response]) -> Response:


### PR DESCRIPTION
We're removing `options` from `/v1/data/query/sql` for Spring 2026 release. Therefore, we need to update the connector logic to request `aggregateQueryOptions` instead of `options`.

Also updated documentation to refer to Visier docs for the available aggregate and list options.